### PR TITLE
Added optional playerctl controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ command=~/.config/i3blocks/scripts/spotify.py
 color=#81b71a
 interval=5
 ```
+
+# Controls
+
+If you have playerctl installed on your system, you can uncomment lines in the script to enable mouse clicks (left/right) to go forward/backward through tracks and to pause/play with middle-click. 

--- a/spotify.py
+++ b/spotify.py
@@ -1,6 +1,18 @@
 #!/usr/bin/python
 
 import dbus
+
+# Uncomment the following lines if you have playerctl installed to allow
+# Left/right clicking to play next/previous songs
+
+#import os
+#if os.environ.get('BLOCK_BUTTON'):
+#    os.system({
+#        '1': "playerctl previous",
+#        '2': "playerctl play-pause",
+#        '3': "playerctl next",
+#    }[os.environ['BLOCK_BUTTON']])
+
 try:
 	bus = dbus.SessionBus()
 	spotify = bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")


### PR DESCRIPTION
Hi,

I added some code to allow easily pausing/playing and going forward and backward through tracks with mouse clicks and middle clicks. It's commented out by default, since it currently requires playerctl.

Thought you & other users of this block might find this useful :)